### PR TITLE
Expand test coverage for service and schema

### DIFF
--- a/tests/test_api_exceptions.py
+++ b/tests/test_api_exceptions.py
@@ -1,0 +1,13 @@
+import pytest
+
+fastapi = pytest.importorskip('fastapi')
+
+from fastapi_toolkit.exceptions.api_exceptions import APIException
+
+
+def test_api_exception_attributes():
+    exc = APIException(message='msg', status_code='CODE', status=500, data={'k':'v'})
+    assert exc.message == 'msg'
+    assert exc.status_code == 'CODE'
+    assert exc.status == 500
+    assert exc.data == {'k':'v'}

--- a/tests/test_base_response.py
+++ b/tests/test_base_response.py
@@ -1,0 +1,18 @@
+import pytest
+
+pydantic = pytest.importorskip('pydantic')
+
+from fastapi_toolkit.schema.base import BaseResponse, BasePaginationResponse
+
+
+def test_base_response_defaults():
+    resp = BaseResponse(data={'id': 1})
+    assert resp.message == 'Operación exitosa'
+    assert resp.status == 'success'
+    assert resp.data == {'id': 1}
+
+
+def test_base_pagination_response():
+    resp = BasePaginationResponse(data=[1, 2], pagination={'page': 1, 'count': 2, 'total': 2})
+    assert resp.pagination['total'] == 2
+    assert resp.data == [1, 2]

--- a/tests/test_base_service.py
+++ b/tests/test_base_service.py
@@ -1,0 +1,90 @@
+import pytest
+
+fastapi = pytest.importorskip('fastapi')
+
+from fastapi_toolkit.aio.service.base import BaseService
+from fastapi_toolkit.exceptions.api_exceptions import (
+    NotFoundException,
+    DatabaseIntegrityException,
+)
+
+class FakeRepository:
+    def __init__(self):
+        self.items = {}
+        self.counter = 0
+
+    async def get_by_id(self, obj_id, **kwargs):
+        return self.items.get(str(obj_id))
+
+    async def get_by_fields(self, filters, **kwargs):
+        for obj in self.items.values():
+            if all(obj.get(k) == v for k, v in filters.items()):
+                return obj
+        return None
+
+    async def create(self, obj):
+        self.counter += 1
+        obj_id = str(self.counter)
+        if isinstance(obj, dict):
+            obj = obj.copy()
+            obj['id'] = obj_id
+        self.items[obj_id] = obj
+        return obj
+
+    async def update(self, obj, data):
+        obj.update(data)
+        return obj
+
+    async def delete(self, obj):
+        self.items.pop(str(obj['id']), None)
+
+    async def build_filter_query(self, search=None, search_fields=None, filters=None, **kwargs):
+        return [
+            obj for obj in self.items.values()
+            if all(obj.get(k) == v for k, v in (filters or {}).items())
+        ]
+
+    async def paginate(self, query, page, count):
+        total = len(query)
+        start = count * (page - 1)
+        return query[start:start + count], total
+
+class ExampleService(BaseService):
+    duplicate_check_fields = ['name']
+
+    def __init__(self, repository):
+        super().__init__(repository)
+
+@pytest.mark.anyio
+async def test_create_and_duplicate_check():
+    service = ExampleService(FakeRepository())
+    await service.create({'name': 'a'})
+    with pytest.raises(DatabaseIntegrityException):
+        await service.create({'name': 'a'})
+
+@pytest.mark.anyio
+async def test_crud_flow():
+    repo = FakeRepository()
+    service = ExampleService(repo)
+    item = await service.create({'name': 'a'})
+    retrieved = await service.retrieve(item['id'])
+    assert retrieved['name'] == 'a'
+
+    updated = await service.update(item['id'], {'name': 'b'})
+    assert updated['name'] == 'b'
+
+    result = await service.delete(item['id'])
+    assert result == 'deleted'
+    with pytest.raises(NotFoundException):
+        await service.retrieve(item['id'])
+
+@pytest.mark.anyio
+async def test_list_pagination():
+    repo = FakeRepository()
+    service = ExampleService(repo)
+    for i in range(5):
+        await service.create({'name': f'n{i}'})
+
+    items, total = await service.list(page=2, count=2)
+    assert total == 5
+    assert len(items) == 2

--- a/tests/test_jwt_service.py
+++ b/tests/test_jwt_service.py
@@ -1,0 +1,31 @@
+import os
+import time
+import pytest
+
+jwt = pytest.importorskip('jwt')
+pydantic = pytest.importorskip('pydantic')
+
+from fastapi_toolkit.servicios.thrid.jwt import JWTService
+
+
+def test_create_and_decode_token():
+    service = JWTService()
+    token = service.create_token('user1')
+    data = service.decode_token(token)
+    assert data.sub == 'user1'
+
+
+def test_invalid_token_raises_exception():
+    service = JWTService()
+    with pytest.raises(Exception):
+        service.decode_token('invalid')
+
+
+def test_refresh_token_extends_expiration():
+    service = JWTService()
+    token = service.create_token('user1')
+    original = service.decode_token(token)
+    time.sleep(1)
+    refreshed = service.refresh_token(token)
+    new_data = service.decode_token(refreshed)
+    assert new_data.exp > original.exp


### PR DESCRIPTION
## Summary
- add async tests for BaseService CRUD, duplication logic, and pagination using a fake repository
- add tests for BaseResponse and BasePaginationResponse defaults
- keep tests optional via `pytest.importorskip` when dependencies aren't installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c1a9e71888321a1fa424cef5dadc8